### PR TITLE
Update syntax highlights for Mercury 0.2.

### DIFF
--- a/emacs/syntax-modes/rholang-mode.el
+++ b/emacs/syntax-modes/rholang-mode.el
@@ -18,13 +18,14 @@
 
 (defconst rholang-font-lock-keywords-1
   (list
-   `(,(regexp-opt '("contract" "for" "in" "match" "new" "select" "case") 'words) . font-lock-builtin-face)
+   `(,(regexp-opt '("contract" "for" "in" "if" "else" "match" "new" "select" "case") 'symbols) . font-lock-builtin-face)
    '("\\('\\w*\\)" . font-lock-variable-name-face))
   "Minimal highlighting expressions for Rholang mode")
 
 (defconst rholang-font-lock-keywords-2
   (append rholang-font-lock-keywords-1
-	  (list '("\\<\\(true\\|false\\|Nil\\)\\>" . font-lock-constant-face)))
+    (list
+	  `(,(regexp-opt '("true" "false" "Nil" "Bool" "Int" "String" "Uri" "ByteArray") 'symbols) . font-lock-constant-face)))
   "Additional keywords to highlight in Rholang mode")
 
 ;;;; Colorize tokens and brackets
@@ -36,7 +37,8 @@
 (defconst rholang-font-lock-keywords-3
   (append rholang-font-lock-keywords-2
 	  (list
-	   `(,(regexp-opt '("@" "|" "!" "<-" "<=" "=>" "=" "+" "-" "*" "/") t) . font-lock-keyword-face)
+	   `(,(regexp-opt '("and" "or" "not" "bundle" "bundle0" "bundle+" "bundle-") 'symbols) . font-lock-keyword-face)
+	   `(,(regexp-opt '("@" "|" "!" "<-" "<=" "=>" "=" "+" "-" "*" "/" "...") t) . font-lock-keyword-face)
 	   `(,(regexp-opt '("{" "[" "(" ")" "]" "}") t) . font-lock-comment-delimiter-face)))
   "Additional keywords to highlight operators and brackets in Rholang mode")
 
@@ -49,15 +51,19 @@
 
 
 (defvar rholang-mode-syntax-table
-  (let ((st (make-syntax-table)))
-    (modify-syntax-entry ?_ "w" st)    ; for Emacs to consider underscored_words as a single word
+  (let ((rholang-syntax-table (make-syntax-table)))
+      ;; Consider underscored_word as a single word.
+      (modify-syntax-entry ?_ "w" rholang-syntax-table)
 
-    ;; Enable comments -- going full C++ style is probably going overboard; to the best of
-    ;; my knowledge, Rholang only uses // style comments...
-    (modify-syntax-entry ?/  ". 124b" st) ; enable C++ style commenst // (1b) and /* (24)
-    (modify-syntax-entry ?*  ". 23"   st) ; enable C++ style comments /* (23)
-    (modify-syntax-entry ?\n "> b"    st) ; \n ends "b-style" commenst (for //)
-    st)
+      ;; Enable comments -- going full C++ style is probably going overboard; to the best of
+      ;; my knowledge, Rholang only uses // style comments...
+      (modify-syntax-entry ?/  ". 124b" rholang-syntax-table) ; enable C++ style comments // (1b) and /* (24)
+      (modify-syntax-entry ?*  ". 23"   rholang-syntax-table) ; enable C++ style comments /* (23)
+      (modify-syntax-entry ?\n "> b"    rholang-syntax-table) ; \n ends "b-style" comments (for //)
+
+      ;; Recognize `uri strings` as strings.  Emacs automatically handles "\\" and "\`".
+      (modify-syntax-entry ?` "\"" rholang-syntax-table)
+    rholang-syntax-table)
   "Syntax table for Rholang mode")
 
 

--- a/vim/syntax/rholang.vim
+++ b/vim/syntax/rholang.vim
@@ -8,7 +8,7 @@ if exists("b:current_syntax")
 endif
 
 " Rholang Keywords
-syn keyword rholangLanguageKeywords contract for in match new select case
+syn keyword rholangLanguageKeywords contract for in if else match new select case bundle bundle0 bundle+ bundle-
 
 syn keyword rholangToDo contained TODO FIXME XXX NOTE
 
@@ -18,8 +18,13 @@ syn match rholangLineComment "//.*" contains=rholangToDo
 "syn region rholangFold start="{" end="}" transparent fold
 
 " Rholang strings (taken from Java Strings)
-syn match rholangSpecialChar contained "\\\([4-9]\d\|[0-3]\d\d|[\"\\'ntbrf]\|u\x\{4\}\)"
-syn region rholangString start=+"+ end=+"+ contains=rholangSpeclialChar
+syn match rholangStringSpecialChar contained "\\\([4-9]\d\|[0-3]\d\d\|[\"\\'ntbrf]\|u\x\{4\}\)"
+syn region rholangString start=+"+ end=+"+ contains=rholangStringSpecialChar
+
+" Rholang URIs
+syn match rholangURISpecialChar contained "\\\([4-9]\d\|[0-3]\d\d\|[`\\'ntbrf]\|u\x\{4\}\)"
+syn region rholangURI start=+`+ end=+`+ contains=rholangURISpecialChar
+
 
 " Rholang numbers -- shamelessly stolen from Java numbers
 " (and may be subject to change...)
@@ -30,7 +35,7 @@ syn match rholangNumber          "\<\d\(\d\|_\d\)*\([eE][-+]\=\d\(\d\|_\d\)*\)\=
 
 
 " Special Rholang values
-syn match rholangValue 'Nil\|true\|false'
+syn match rholangValue 'Nil\|true\|false\|Bool\|Int\|String\|Uri\|ByteArray'
 
 " Rholang operators
 """ Theoretically I'd like the entire channel highlighed.  It seems to me
@@ -42,7 +47,7 @@ syn match rholangValue 'Nil\|true\|false'
 syn match rholangChannel  '@'
 
 syn match rholangOperator '+\|-\|\*\|/[^/]\|==\|='
-syn match rholangOperator '!\||\|<-\|<=\|=>\|_'
+syn match rholangOperator '!\||\|<-\|<=\|=>\|_\|\<not\>\|\<and\>\|\<or\>\|\.\.\.'
 
 syn match rholangBracket '(\|\[\|{\|}\|\]\|)'
 
@@ -53,6 +58,7 @@ hi def link rholangLineComment        Comment
 
 hi def link rholangNumber             Number
 hi def link rholangString             Constant
+hi def link rholangURI                Constant
 
 hi def link rholangOperator           Operator
 hi def link rholangChannel            Function


### PR DESCRIPTION
Updated syntaxt highlighting for Emacs and Vim to better match the
changes that have been made up to Rholang Mercury 0.2.